### PR TITLE
WIP: Update attribute description in documentation strings.

### DIFF
--- a/sklearn/decomposition/fastica_.py
+++ b/sklearn/decomposition/fastica_.py
@@ -436,6 +436,9 @@ class FastICA(BaseEstimator, TransformerMixin):
     mixing_ : array, shape (n_features, n_components)
         The mixing matrix.
 
+    mean_ : array, shape(n_features)
+        The mean over features. Only set if `self.whiten` is True.
+
     n_iter_ : int
         If the algorithm is "deflation", n_iter is the
         maximum number of iterations run across all components. Else

--- a/sklearn/decomposition/nmf.py
+++ b/sklearn/decomposition/nmf.py
@@ -1192,6 +1192,11 @@ class NMF(BaseEstimator, TransformerMixin):
     components_ : array, [n_components, n_features]
         Factorization matrix, sometimes called 'dictionary'.
 
+    n_components_ : integer
+        The number of components. It is same to the `n_components` parameter
+        if it was given. Otherwise, it will be same with the number of
+        features.
+
     reconstruction_err_ : number
         Frobenius norm of the matrix difference, or beta-divergence, between
         the training data ``X`` and the reconstructed data ``WH`` from

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -453,7 +453,7 @@ class GaussianRandomProjection(BaseRandomProjection):
 
     Attributes
     ----------
-    n_component_ : int
+    n_components_ : int
         Concrete number of components computed when n_components="auto".
 
     components_ : numpy array of shape [n_components, n_features]

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -573,7 +573,7 @@ class SparseRandomProjection(BaseRandomProjection):
 
     Attributes
     ----------
-    n_component_ : int
+    n_components_ : int
         Concrete number of components computed when n_components="auto".
 
     components_ : CSR matrix with shape [n_components, n_features]


### PR DESCRIPTION
*   `NMF`
    Describe the `n_components_` attribute in addition to n_components parameter.
    The attribute value will be set to n_features if no n_components value given to the constructor,
    while the `n_components` value will be None.

*   `GaussianRandomProjection`
    Fix typo in attribute description: `n_component` -> `n_components`

*   `SparseRandomProjection`
    Fix typo in attribute description: `n_component` -> `n_components`

*   `FastICA`
    Describe the `mean_` attribute.